### PR TITLE
Add Admin UI and token-protected admin endpoints

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header, Depends, status
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from pydantic import BaseModel
+from typing import Optional
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -130,3 +132,83 @@ def unregister_from_activity(activity_name: str, email: str):
     # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+# --- Admin support (simple token-based auth) ---
+ADMIN_TOKEN = os.environ.get("ADMIN_TOKEN", "secret-token")
+
+
+def admin_auth(x_admin_token: str = Header(None)):
+    if x_admin_token != ADMIN_TOKEN:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid admin token")
+    return True
+
+
+class ActivityIn(BaseModel):
+    name: str
+    description: str
+    schedule: str
+    max_participants: int
+
+
+class ActivityUpdate(BaseModel):
+    description: Optional[str] = None
+    schedule: Optional[str] = None
+    max_participants: Optional[int] = None
+
+
+@app.get("/admin/activities")
+def admin_get_activities(token: bool = Depends(admin_auth)):
+    return activities
+
+
+@app.post("/admin/activities", status_code=201)
+def admin_create_activity(payload: ActivityIn, token: bool = Depends(admin_auth)):
+    if payload.name in activities:
+        raise HTTPException(status_code=400, detail="Activity already exists")
+    activities[payload.name] = {
+        "description": payload.description,
+        "schedule": payload.schedule,
+        "max_participants": payload.max_participants,
+        "participants": []
+    }
+    return {"message": f"Activity '{payload.name}' created"}
+
+
+@app.put("/admin/activities/{activity_name}")
+def admin_update_activity(activity_name: str, payload: ActivityUpdate, token: bool = Depends(admin_auth)):
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    activity = activities[activity_name]
+    if payload.description is not None:
+        activity["description"] = payload.description
+    if payload.schedule is not None:
+        activity["schedule"] = payload.schedule
+    if payload.max_participants is not None:
+        activity["max_participants"] = payload.max_participants
+    activities[activity_name] = activity
+    return {"message": f"Activity '{activity_name}' updated"}
+
+
+@app.delete("/admin/activities/{activity_name}")
+def admin_delete_activity(activity_name: str, token: bool = Depends(admin_auth)):
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    del activities[activity_name]
+    return {"message": f"Activity '{activity_name}' deleted"}
+
+
+@app.get("/admin/activities/{activity_name}/participants")
+def admin_list_participants(activity_name: str, token: bool = Depends(admin_auth)):
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    return activities[activity_name]["participants"]
+
+
+@app.delete("/admin/activities/{activity_name}/participants")
+def admin_remove_participant(activity_name: str, email: str, token: bool = Depends(admin_auth)):
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    if email not in activities[activity_name]["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+    activities[activity_name]["participants"].remove(email)
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/static/admin.html
+++ b/src/static/admin.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin — Mergington Activities</title>
+    <style>
+      body { font-family: system-ui, Arial, sans-serif; padding: 1rem; }
+      h1 { margin-bottom: 0.25rem }
+      #activities { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+      .card { border: 1px solid #ddd; padding: 1rem; border-radius: 6px; background: #fff }
+      .muted { color: #666; font-size: 0.9rem }
+      .actions { margin-top: 0.75rem }
+      button { margin-right: 0.5rem }
+      form { margin-bottom: 1.25rem }
+      label { display:block; margin-top:0.5rem }
+      input, textarea { width: 100%; padding: 6px; box-sizing: border-box }
+    </style>
+  </head>
+  <body>
+    <h1>Admin — Activities</h1>
+    <p class="muted">This admin UI uses a simple token header <code>X-ADMIN-TOKEN</code> to authenticate. The default token (for local testing) is <code>secret-token</code>. Set the <code>ADMIN_TOKEN</code> env var on the server for production.</p>
+
+    <section id="create">
+      <h3>Create activity</h3>
+      <form id="create-form">
+        <label for="name">Name</label>
+        <input id="name" required />
+        <label for="description">Description</label>
+        <textarea id="description" rows="2"></textarea>
+        <label for="schedule">Schedule</label>
+        <input id="schedule" />
+        <label for="max">Max Participants</label>
+        <input id="max" type="number" min="1" value="10" />
+        <div style="margin-top:0.5rem"><button type="submit">Create</button></div>
+      </form>
+    </section>
+
+    <section>
+      <h3>Existing activities</h3>
+      <div id="activities">Loading…</div>
+    </section>
+
+    <script src="/static/admin.js"></script>
+  </body>
+</html>

--- a/src/static/admin.js
+++ b/src/static/admin.js
@@ -1,0 +1,82 @@
+// Simple admin UI for managing activities
+let ADMIN_TOKEN = null
+
+async function api(path, opts={}){
+  if(!ADMIN_TOKEN){
+    ADMIN_TOKEN = prompt('Enter admin token (default: secret-token)') || 'secret-token'
+  }
+  const headers = opts.headers || {}
+  headers['X-ADMIN-TOKEN'] = ADMIN_TOKEN
+  opts.headers = headers
+  const res = await fetch(path, opts)
+  if(!res.ok){
+    const text = await res.text()
+    alert('Error: ' + res.status + '\n' + text)
+    throw new Error('API error')
+  }
+  if(res.status === 204) return null
+  return res.json()
+}
+
+function renderActivities(data){
+  const container = document.getElementById('activities')
+  container.innerHTML = ''
+  Object.entries(data).forEach(([name, act]) => {
+    const div = document.createElement('div')
+    div.className = 'card'
+    div.innerHTML = `
+      <strong>${name}</strong>
+      <div class="muted">${act.schedule}</div>
+      <p>${act.description}</p>
+      <div>Participants: ${act.participants.length}/${act.max_participants}</div>
+      <div class="actions">
+        <button onclick="showParticipants('${encodeURIComponent(name)}')">View Participants</button>
+        <button onclick="deleteActivity('${encodeURIComponent(name)}')">Delete</button>
+      </div>
+    `
+    container.appendChild(div)
+  })
+}
+
+async function loadActivities(){
+  const data = await api('/admin/activities')
+  renderActivities(data)
+}
+
+async function deleteActivity(nameEnc){
+  const name = decodeURIComponent(nameEnc)
+  if(!confirm(`Delete activity "${name}"?`)) return
+  await api(`/admin/activities/${encodeURIComponent(name)}`, { method: 'DELETE' })
+  await loadActivities()
+}
+
+async function showParticipants(nameEnc){
+  const name = decodeURIComponent(nameEnc)
+  const parts = await api(`/admin/activities/${encodeURIComponent(name)}/participants`)
+  const list = parts.map(p => `<li>${p} <button onclick="removeParticipant('${encodeURIComponent(name)}','${encodeURIComponent(p)}')">Remove</button></li>`).join('')
+  alert(`Participants for ${name}:\n\n${parts.join('\n') || '(none)'}`)
+}
+
+async function removeParticipant(nameEnc, emailEnc){
+  const name = decodeURIComponent(nameEnc)
+  const email = decodeURIComponent(emailEnc)
+  if(!confirm(`Remove ${email} from ${name}?`)) return
+  await api(`/admin/activities/${encodeURIComponent(name)}/participants?email=${encodeURIComponent(email)}`, { method: 'DELETE' })
+  await loadActivities()
+}
+
+document.getElementById('create-form').addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const payload = {
+    name: document.getElementById('name').value.trim(),
+    description: document.getElementById('description').value.trim(),
+    schedule: document.getElementById('schedule').value.trim(),
+    max_participants: parseInt(document.getElementById('max').value, 10) || 10
+  }
+  await api('/admin/activities', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify(payload) })
+  document.getElementById('create-form').reset()
+  await loadActivities()
+})
+
+// initial load
+loadActivities().catch(()=>{})

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,7 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div style="margin-top:0.5rem"><a href="/static/admin.html">Admin UI</a></div>
     </header>
 
     <main>


### PR DESCRIPTION
This PR adds a minimal Admin UI + backend endpoints to manage activities and participants.

What I changed:
- New `/static/admin.html` and `/static/admin.js` — single-page admin interface (token-based prompt).
- New admin endpoints (token-protected using `X-ADMIN-TOKEN` header):
  - `GET /admin/activities` — list activities
  - `POST /admin/activities` — create activity (JSON payload)
  - `PUT /admin/activities/{activity_name}` — update activity
  - `DELETE /admin/activities/{activity_name}` — delete activity
  - `GET /admin/activities/{activity_name}/participants` — list participants
  - `DELETE /admin/activities/{activity_name}/participants?email=...` — remove participant
- Simple token protection using `ADMIN_TOKEN` env var (default `secret-token` for local testing).

Notes:
- Data is still in-memory (no DB changes in this PR). Future work: persist models, add proper auth.
- Basic input validation and error handling included; syntax checked.

Files changed: `src/app.py`, `src/static/admin.html`, `src/static/admin.js`, `src/static/index.html`
